### PR TITLE
Un-bitrot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,17 +13,18 @@ RUN apt-get update && apt-get install --no-install-recommends -yy -qq \
     libtool \
     curl \
     g++ \
-    unzip
+    unzip \
+    python-is-python3
 
-# Add stretch backports
-RUN echo 'deb http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
-RUN apt-get update && apt-get install -yy -qq \
-    openjdk-11-jdk
+## Add stretch backports
+#RUN echo 'deb http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+#RUN apt-get update && apt-get install -yy -qq \
+#    openjdk-11-jdk
 
 # Runtime dependencies
-RUN pip3 install --upgrade wheel setuptools
+RUN python -m pip install --upgrade wheel setuptools
 ADD requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN python -m pip install -r requirements.txt
 RUN apt-get update && apt-get install --no-install-recommends -yy -qq psmisc iptables
 
 # Test dependencies
@@ -31,30 +32,31 @@ RUN apt-get update && apt-get install --no-install-recommends -yy -qq \
     tmux \
     screen \
     strace \
-    linux-tools \
+    linux-tools-common \
     tcpdump \
     lsof \
     vim \
     netcat \
-    locales-all
+    locales-all \
+    git
 
 # Add ocons dependencies
 RUN bash -c "sh <(curl -L https://nixos.org/nix/install) --daemon"
 RUN bash -c "echo 'experimental-features = nix-command flakes' > /etc/nix/nix.conf"
 
-# Build ocons impl and client
-# Required for silly reasons that ocaml has difficulty 
-RUN git init . 
-ADD ./reckon/systems/ocons/ocons-src/flake.nix ./reckon/systems/ocons/ocons-src/flake.lock ./reckon/systems/ocons/ocons-src/dune-project reckon/systems/ocons/ocons-src/
-# Cache reckon build without files (also caches client deps)
-RUN git add . && bash -l -c "nix build -j auto ./reckon/systems/ocons/ocons-src" 
-# Build client
-ADD ./reckon/ocaml_client reckon/ocaml_client
-ADD ./reckon/systems/ocons/clients reckon/systems/ocons/clients
-RUN git add . && bash -l -c "nix build ./reckon/systems/ocons/clients"
-# Build build server
-ADD ./reckon/systems/ocons/ocons-src reckon/systems/ocons/ocons-src
-RUN git add . && bash -l -c "nix build -j auto ./reckon/systems/ocons/ocons-src"
+## Build ocons impl and client
+## Required for silly reasons that ocaml has difficulty 
+#RUN git init . 
+#ADD ./reckon/systems/ocons/ocons-src/flake.nix ./reckon/systems/ocons/ocons-src/flake.lock ./reckon/systems/ocons/ocons-src/dune-project reckon/systems/ocons/ocons-src/
+## Cache reckon build without files (also caches client deps)
+#RUN git add . && bash -l -c "nix build -j auto ./reckon/systems/ocons/ocons-src" 
+## Build client
+#ADD ./reckon/ocaml_client reckon/ocaml_client
+#ADD ./reckon/systems/ocons/clients reckon/systems/ocons/clients
+#RUN git add . && bash -l -c "nix build ./reckon/systems/ocons/clients"
+## Build build server
+#ADD ./reckon/systems/ocons/ocons-src reckon/systems/ocons/ocons-src
+#RUN git add . && bash -l -c "nix build -j auto ./reckon/systems/ocons/ocons-src"
 
 # Add reckon code
 ADD . .

--- a/Dockerfile.mininet
+++ b/Dockerfile.mininet
@@ -1,5 +1,4 @@
-# cloned from https://github.com/mininet/mininet/pull/968
-FROM debian:stretch-slim
+FROM ubuntu:22.04
 
 USER root
 WORKDIR /root
@@ -17,7 +16,6 @@ RUN apt-get update -yq && apt-get install -yq \
 
 RUN apt update -yq && apt install -yq \
     build-essential \
-    zlib1g-dev \
     libncurses5-dev \
     libgdbm-dev \
     libnss3-dev \
@@ -26,19 +24,21 @@ RUN apt update -yq && apt install -yq \
     libffi-dev \
     libsqlite3-dev \
     wget \
-    libbz2-dev
+    libbz2-dev \
+    zlib1g-dev \
+    python-is-python3
 
-RUN apt update -yq && \
-    mkdir /python && \
-    cd /python && \
-    wget https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz && \
-    tar -xf Python-3.9.10.tgz && \
-    cd Python-3.9.10 && \
-    ./configure --enable-optimizations --with-ssl && \
-    make -j 4 && \
-    sudo make install
+# RUN apt update -yq && \
+#     mkdir /python && \
+#     cd /python && \
+#     wget https://www.python.org/ftp/python/3.9.10/Python-3.9.10.tgz && \
+#     tar -xf Python-3.9.10.tgz && \
+#     cd Python-3.9.10 && \
+#     ./configure --enable-optimizations --with-ssl && \
+#     make -j 4 && \
+#     sudo make install
 
-RUN bash -c "ln -s `which python3` /usr/local/bin/python"
+# RUN bash -c "ln -s `which python3` /usr/local/bin/python"
 
 ARG INSTALL_FLAGS="-fnv"
 COPY ./vendor/mininet /root/mininet

--- a/Dockerfile.zookeeper
+++ b/Dockerfile.zookeeper
@@ -5,9 +5,9 @@ RUN nix-channel --update
 # Install Zookeeper binaries
 RUN mkdir -p reckon/systems/zookeeper/bins
 RUN cd reckon/systems/zookeeper/bins \
-    && nix-shell -p wget --command "wget https://dlcdn.apache.org/zookeeper/zookeeper-3.5.10/apache-zookeeper-3.5.10-bin.tar.gz" \
-    && tar -zxf apache-zookeeper-3.5.10-bin.tar.gz \
-    && rm apache-zookeeper-3.5.10-bin.tar.gz
+    && nix-shell -p wget --command "wget https://archive.apache.org/dist/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9-bin.tar.gz" \
+    && tar -zxf apache-zookeeper-3.5.9-bin.tar.gz \
+    && rm apache-zookeeper-3.5.9-bin.tar.gz
 
 # Build and cache nix environments
 COPY reckon/javaclient/flake.* reckon/javaclient/

--- a/reckon/__main__.py
+++ b/reckon/__main__.py
@@ -66,13 +66,12 @@ if __name__ == "__main__":
 
           print("BENCHMARK: testing connectivity, and allowing network to settle")
           net.pingAll()
-          from time import sleep
-
-          sleep(5)
 
           print("BENCHMARK: Starting Test")
 
-          run_test(
+          from multiprocessing import Process
+
+          p = Process(target = run_test, args=(
               args.result_location,
               clients,
               ops_provider,
@@ -80,7 +79,10 @@ if __name__ == "__main__":
               system,
               cluster,
               failures,
-          )
+          ))
+          p.start()
+          p.join(600)
+          p.terminate()
         finally:
           for stopper in stoppers.values():
               stopper()

--- a/reckon/reckon_types.py
+++ b/reckon/reckon_types.py
@@ -227,6 +227,7 @@ class AbstractSystem(ABC):
         self.client_class = self.get_client(args)
         self.client_type = args.client
         self.data_dir = args.data_dir
+        self.failure_timeout = args.failure_timeout
 
         super(AbstractSystem, self).__init__()
 

--- a/reckon/systems/__init__.py
+++ b/reckon/systems/__init__.py
@@ -44,12 +44,18 @@ def register_system_args(parser):
         help="Location of any data stores, should be empty at the start of each test.",
     )
 
-
     system_group.add_argument(
         "--new_client_per_request",
         default=False,
         help="Should a new client be created per request.",
         type=lambda x: bool(strtobool(x)),
+    )
+
+    system_group.add_argument(
+        "--failure_timeout",
+        default=1.0,
+        help="Timeout until failure detector triggers an election",
+        type = float,
     )
 
 

--- a/reckon/systems/etcd/clients/go/client.go
+++ b/reckon/systems/etcd/clients/go/client.go
@@ -43,15 +43,27 @@ func main() {
 	dialTimeout := 10 * time.Second
 
 	gen_cli := func() (rc_go.Client, error){
-		cli_v3, err := clientv3.New(clientv3.Config{
-			Endpoints:            endpoints,
-			DialTimeout:          dialTimeout,
-			DialKeepAliveTime:    dialTimeout / 2,
-			DialKeepAliveTimeout: dialTimeout * 2,
-			AutoSyncInterval:     dialTimeout / 2,
-		})
-		cli := rc_cli{Client:cli_v3}
-		return cli,err
+    if (true) {
+      cli_v3, err := clientv3.New(clientv3.Config{
+        Endpoints:            endpoints,
+        //			DialTimeout:          dialTimeout,
+        //			DialKeepAliveTime:    dialTimeout / 2,
+        //			DialKeepAliveTimeout: dialTimeout * 2,
+        //			AutoSyncInterval:     dialTimeout / 2,
+      })
+      cli := rc_cli{Client:cli_v3}
+      return cli,err
+    } else {
+      cli_v3, err := clientv3.New(clientv3.Config{
+        Endpoints:            endpoints,
+        DialTimeout:          dialTimeout,
+        DialKeepAliveTime:    dialTimeout / 2,
+        DialKeepAliveTimeout: dialTimeout * 2,
+        AutoSyncInterval:     dialTimeout / 2,
+      })
+      cli := rc_cli{Client:cli_v3}
+      return cli,err
+    }
 	}
 	rc_go.Run(gen_cli, *f_client_id, *f_new_client_per_request)
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tqdm
 numpy
 pytest
-pydantic
+pydantic==1.*
 pandas

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,9 +1,2 @@
 # Clean mininet
 sudo mn -c
-# Clean up all processes from previous runs (TODO track from mininet?)
-sudo killall -9 client
-sudo killall -9 etcd etcdctl ocaml-paxos java
-# Clean up zookeeper
-rm -rf ../systems/zookeeper/scripts/zktmp/*
-# Remove benchmark socket, to prevent mixing of data from runs
-sudo rm -rf ../src/utils/sockets/benchmark.sock

--- a/scripts/tester.py
+++ b/scripts/tester.py
@@ -45,12 +45,14 @@ default_parameters = {
         'tcpdump':False,
         'arrival_process':'uniform',
         'repeat':-1,
+        'failure_timeout':1,
         'notes':{},
         }
 
 def run_test(folder_path, config : Dict[str, Any]):
     run('rm -rf /data/*', shell=True).check_returncode()
     run('mn -c', shell=True).check_returncode()
+    run('pkill client', shell=True)
 
     uid = uuid.uuid4()
 
@@ -77,6 +79,7 @@ def run_test(folder_path, config : Dict[str, Any]):
         f"--rate {params['rate']} --duration {params['duration']}",
         f"--arrival-process {params['arrival_process']}",
         f"--system_logs {log_path} --result-location {result_path} --data-dir=/data",
+        f"--failure_timeout {params['failure_timeout']}"
         ])
 
     run(f'mkdir -p {result_folder}', shell=True).check_returncode()
@@ -103,61 +106,20 @@ folder_path = f"/results/{run_time}"
 
 actions = []
 
+paxos = ('ocons-paxos', 'ocaml')
+raft = ('ocons-raft', 'ocaml')
+
 systems = [('etcd', 'go'),('zookeeper', 'java')] +\
                [('etcd-pre-vote', 'go'),('zookeeper-fle', 'java')]
 
 clean_room_systems = [('ocons-paxos', 'ocaml')] +\
                [ ('ocons-raft', 'ocaml'), ('ocons-raft+sbn', 'ocaml'), ('ocons-raft-pre-vote', 'ocaml'), ('ocons-raft-pre-vote+sbn', 'ocaml')]
 
-
-# Leader election heat maps
-for sys, repeat in it.product(
-        systems+clean_room_systems,
-        range(4),
-        ):
-    system, client = sys
-    actions.append(
-            lambda params = {
-                'failure': 'leader-only',
-                'system':system,
-                'client':client,
-                'duration':30,
-                'repeat':repeat,
-                'rate':5000,
-                'delay':75,
-                'nn':str(3),
-                'tcpdump': True,
-                }:
-            run_test(folder_path, params)
-            )
-
-# Leader election bulk
-for sys, repeat in it.product(
-        systems+clean_room_systems,
-        range(100),
-        ):
-    system, client = sys
-    actions.append(
-            lambda params = {
-                'failure': 'leader-only',
-                'system':system,
-                'client':client,
-                'duration':30,
-                'repeat':repeat,
-                'rate':5000,
-                'delay':50,
-                'nn':5,
-                }:
-            run_test(folder_path, params)
-            )
-
-systems_steady = [('etcd', 'go'),('zookeeper', 'java')] #+ [('ocons-paxos', 'ocaml'), ('ocons-raft', 'ocaml')]
-
-# Steady latency (DC and WAN)
-for sys, repeat, nn in it.product(
-        systems_steady,
-        range(10),
-        [1,3,5,7]
+for sys, loss, failure_timeout, repeat in it.product(
+        [('etcd', 'go')],
+        [0, 0.01, 0.1, 1],
+        [0.1, 0.2, 0.4, 0.8, 1.6],
+        range(4)
         ):
     system, client = sys
     actions.append(
@@ -167,49 +129,116 @@ for sys, repeat, nn in it.product(
                 'client':client,
                 'duration':30,
                 'rate':5000,
-                'delay':50,
-                'nn':nn,
-                'repeat':repeat,
-                'notes':'steady-latency',
-                }:
-            run_test(folder_path, params)
-            )
-    actions.append(
-            lambda params = {
-                'failure': 'none',
-                'system':system,
-                'client':client,
-                'duration':30,
-                'rate':5000,
-                'delay':0,
-                'nn':nn,
-                'repeat':repeat,
-                'notes':'steady-latency',
-                }:
-           run_test(folder_path, params)
-            )
-
-# Steady rate-lat WAN
-for sys, rate, repeat in it.product(
-        systems_steady,
-        [1000,5000,10000,15000,20000,25000,30000,35000],
-        range(2),
-        ):
-    system, client = sys
-    actions.append(
-            lambda params = {
-                'failure': 'none',
-                'system':system,
-                'client':client,
-                'duration':30,
-                'rate':rate,
                 'delay':50,
                 'nn':3,
                 'repeat':repeat,
-                'notes':'rate-lat',
+                'loss':loss,
+                'failure_timeout':failure_timeout,
                 }:
             run_test(folder_path, params)
             )
+
+
+## Leader election heat maps
+#for sys, repeat in it.product(
+#        systems+clean_room_systems,
+#        range(4),
+#        ):
+#    system, client = sys
+#    actions.append(
+#            lambda params = {
+#                'failure': 'leader-only',
+#                'system':system,
+#                'client':client,
+#                'duration':30,
+#                'repeat':repeat,
+#                'rate':5000,
+#                'delay':75,
+#                'nn':str(3),
+#                'tcpdump': True,
+#                }:
+#            run_test(folder_path, params)
+#            )
+
+## Leader election bulk
+#for sys, repeat in it.product(
+#        systems+clean_room_systems,
+#        range(100),
+#        ):
+#    system, client = sys
+#    actions.append(
+#            lambda params = {
+#                'failure': 'leader-only',
+#                'system':system,
+#                'client':client,
+#                'duration':30,
+#                'repeat':repeat,
+#                'rate':5000,
+#                'delay':50,
+#                'nn':5,
+#                }:
+#            run_test(folder_path, params)
+#            )
+
+systems_steady = [('etcd', 'go'),('zookeeper', 'java')] #+ [('ocons-paxos', 'ocaml'), ('ocons-raft', 'ocaml')]
+
+## Steady latency (DC and WAN)
+#for sys, repeat, nn in it.product(
+#        systems_steady,
+#        range(10),
+#        [1,3,5,7]
+#        ):
+#    system, client = sys
+#    actions.append(
+#            lambda params = {
+#                'failure': 'none',
+#                'system':system,
+#                'client':client,
+#                'duration':30,
+#                'rate':5000,
+#                'delay':50,
+#                'nn':nn,
+#                'repeat':repeat,
+#                'notes':'steady-latency',
+#                }:
+#            run_test(folder_path, params)
+#            )
+#    actions.append(
+#            lambda params = {
+#                'failure': 'none',
+#                'system':system,
+#                'client':client,
+#                'duration':30,
+#                'rate':5000,
+#                'delay':0,
+#                'nn':nn,
+#                'repeat':repeat,
+#                'notes':'steady-latency',
+#                }:
+#           run_test(folder_path, params)
+#            )
+#
+## Steady rate-lat WAN
+#for sys, rate, repeat in it.product(
+#        systems_steady,
+#        [1000,5000,10000,15000,20000,25000,30000,35000],
+#        range(2),
+#        ):
+#    system, client = sys
+#    actions.append(
+#            lambda params = {
+#                'failure': 'none',
+#                'system':system,
+#                'client':client,
+#                'duration':30,
+#                'rate':rate,
+#                'delay':50,
+#                'nn':3,
+#                'repeat':repeat,
+#                'notes':'rate-lat',
+#                }:
+#            run_test(folder_path, params)
+#            )
 
 # Shuffle to isolate ordering effects
 rng.shuffle(actions)


### PR DESCRIPTION
Previously reckon used debian-stretch as the base for its docker container.
This version has been archived, so this repository needs to be updated to use a newer version.
The minimal change is to update it to ubuntu 22.04.

Other changes are:
- Add timeout for tests where the SUT is never stable
- Add failure detector timeout 
  - This hooks into the leader election timeout for etcd